### PR TITLE
Sample for whenURI feature to load UI without refreshing the entire page

### DIFF
--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/pom.xml
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/pom.xml
@@ -40,7 +40,7 @@
 		<dependency>
 			<groupId>com.webfirmframework</groupId>
 			<artifactId>wffweb</artifactId>
-			<version>12.0.0-beta</version>
+			<version>12.0.0-beta.1</version>
 			<scope>compile</scope>
 		</dependency>
 	</dependencies>

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/web/pom.xml
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/web/pom.xml
@@ -51,6 +51,10 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>3.3.1</version>
+				<configuration>
+<!-- location for war file other than target directory-->
+<!--					<outputDirectory>~/servers/apache-tomcat-10.0.8/webapps</outputDirectory>-->
+				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/web/src/main/webapp/WEB-INF/web.xml
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/web/src/main/webapp/WEB-INF/web.xml
@@ -5,7 +5,7 @@
 	id="WebApp_ID" version="3.1">
 	<display-name>production-sample-with-foundation-css-framework</display-name>
 	<welcome-file-list>
-		<welcome-file>index</welcome-file>
+		<welcome-file>ui</welcome-file>
 		<welcome-file>index.html</welcome-file>
 	</welcome-file-list>
 

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/web/src/main/webapp/assets/js/app.js
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/web/src/main/webapp/assets/js/app.js
@@ -1,1 +1,14 @@
 
+const wffGlobalListeners = new function() {
+
+    this.onSetURI = function(event) {
+//        console.log('wffGlobalListeners > onSetURI', event);
+        loadingIcon.hidden = false;
+    };
+    this.afterSetURI = function(event) {
+//        console.log('wffGlobalListeners > afterSetURI', event);
+        loadingIcon.hidden = true;
+    };
+
+};
+

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebconfig/src/main/java/com/webfirmframework/wffwebconfig/page/IndexPage.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebconfig/src/main/java/com/webfirmframework/wffwebconfig/page/IndexPage.java
@@ -2,6 +2,8 @@ package com.webfirmframework.wffwebconfig.page;
 
 import com.webfirmframework.wffweb.server.page.BrowserPage;
 import com.webfirmframework.wffweb.tag.html.AbstractHtml;
+import com.webfirmframework.wffweb.tag.html.attribute.event.ServerMethod;
+import com.webfirmframework.wffweb.wffbm.data.WffBMObject;
 import com.webfirmframework.wffwebconfig.AppSettings;
 import com.webfirmframework.wffwebconfig.server.constants.ServerConstants;
 import com.webfirmframework.ui.page.layout.IndexPageLayout;
@@ -23,7 +25,8 @@ public class IndexPage extends BrowserPage {
 
     private final HttpSession httpSession;
 
-    public IndexPage(HttpSession httpSession) {
+    public IndexPage(HttpSession httpSession, String uri) {
+        super.setURI(uri);
         this.httpSession = httpSession;
     }
 
@@ -52,6 +55,17 @@ public class IndexPage extends BrowserPage {
         return new IndexPageLayout(this, httpSession);
     }
 
+    @Override
+    protected void afterRender(AbstractHtml rootTag) {
+        super.addServerMethod("urlPathChanged", new ServerMethod() {
+            @Override
+            public WffBMObject invoke(Event event) {
+                IndexPage.super.setURI((String) event.data().getValue("path"));
+                return null;
+            }
+        });
+    }
+
     // this is new since 3.0.18
     @Override
     protected void onInitialClientPing(AbstractHtml rootTag) {
@@ -63,4 +77,19 @@ public class IndexPage extends BrowserPage {
     public HttpSession getHttpSession() {
         return httpSession;
     }
+
+    @Override
+    protected void beforeURIChange(String uriBefore, String uriAfter) {
+//        System.out.println("IndexPage.beforeURIChange");
+//        System.out.println("uriBefore = " + uriBefore);
+//        System.out.println("uriAfter = " + uriAfter);
+    }
+
+    @Override
+    protected void uriChanged(String uriBefore, String uriAfter) {
+//        System.out.println("IndexPage.uriChanged");
+//        System.out.println("uriBefore = " + uriBefore);
+//        System.out.println("uriAfter = " + uriAfter);
+    }
+
 }

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebconfig/src/main/java/com/webfirmframework/wffwebconfig/server/servlet/IndexPageServlet.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebconfig/src/main/java/com/webfirmframework/wffwebconfig/server/servlet/IndexPageServlet.java
@@ -19,7 +19,7 @@ import java.util.logging.Logger;
 /**
  * Servlet implementation class HomePageServlet
  */
-@WebServlet({ "/index" })
+@WebServlet(urlPatterns = { "/ui/*" })
 public class IndexPageServlet extends HttpServlet {
 
     private static final long serialVersionUID = 1L;
@@ -52,13 +52,21 @@ public class IndexPageServlet extends HttpServlet {
     protected void doGet(HttpServletRequest request,
             HttpServletResponse response) throws ServletException, IOException {
 
+        if (request.getRequestURI().endsWith("/ui")) {
+            response.sendRedirect(request.getRequestURI() + "/");
+            return;
+        } else if (request.getRequestURI().equals(request.getContextPath() + "/")) {
+            response.sendRedirect(request.getContextPath() + "/ui/");
+            return;
+        }
+
         response.setContentType("text/html;charset=utf-8");
 
         try (OutputStream os = response.getOutputStream();) {
 
             HttpSession session = request.getSession();
 
-            IndexPage indexPage = new IndexPage(request.getSession());
+            IndexPage indexPage = new IndexPage(request.getSession(), request.getRequestURI());
 
             BrowserPageContext.INSTANCE.addBrowserPage(session.getId(),
                     indexPage);

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/common/NavigationURI.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/common/NavigationURI.java
@@ -1,0 +1,49 @@
+package com.webfirmframework.ui.page.common;
+
+import com.webfirmframework.ui.page.model.DocumentModel;
+import jakarta.servlet.http.HttpSession;
+
+import java.util.function.Predicate;
+
+public enum NavigationURI {
+
+    LOGIN("/ui/login", false, false),
+
+    USER("/ui/user/", true, true),
+
+    VIEW_ITEMS("/ui/user/items/view", false, true),
+
+    ADD_ITEM("/ui/user/items/add", false, true),
+
+    SAMPLE_TEMPLATE1("/ui/user/sampletemplate1", false, true),
+
+    SAMPLE_TEMPLATE2("/ui/user/sampletemplate2", false, true);
+
+    private final String uri;
+
+    private final boolean parentPath;
+
+    private final boolean loginRequired;
+
+    NavigationURI(String uri, boolean parentPath, boolean loginRequired) {
+        this.uri = uri;
+        this.parentPath = parentPath;
+        this.loginRequired = loginRequired;
+    }
+
+    public Predicate<String> getPredicate(DocumentModel documentModel) {
+        HttpSession httpSession = documentModel.httpSession();
+        String contextPath = httpSession.getServletContext().getContextPath();
+        if (!loginRequired) {
+            return uri -> contextPath.concat(this.uri).equals(uri);
+        }
+        if (parentPath) {
+            return uri -> "true".equals(httpSession.getAttribute("loginStatus")) && uri.startsWith(contextPath.concat(this.uri));
+        }
+        return uri -> "true".equals(httpSession.getAttribute("loginStatus")) && uri.equals(contextPath.concat(this.uri));
+    }
+
+    public String getUri(DocumentModel documentModel) {
+        return documentModel.httpSession().getServletContext().getContextPath() + uri;
+    }
+}

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/AddItemComponent.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/AddItemComponent.java
@@ -1,0 +1,18 @@
+package com.webfirmframework.ui.page.component;
+
+import com.webfirmframework.wffweb.tag.html.H1;
+import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Div;
+import com.webfirmframework.wffweb.tag.htmlwff.TagContent;
+
+public class AddItemComponent extends Div {
+
+    public AddItemComponent() {
+        super(null);
+
+        develop();
+    }
+
+    private void develop() {
+        new H1(this).give(TagContent::text, "This is add item");
+    }
+}

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/LoginComponent.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/LoginComponent.java
@@ -1,0 +1,66 @@
+package com.webfirmframework.ui.page.component;
+
+import com.webfirmframework.ui.page.common.NavigationURI;
+import com.webfirmframework.ui.page.css.Bootstrap5CssClass;
+import com.webfirmframework.ui.page.model.DocumentModel;
+import com.webfirmframework.wffweb.tag.html.attribute.AttributeNameConstants;
+import com.webfirmframework.wffweb.tag.html.attribute.Name;
+import com.webfirmframework.wffweb.tag.html.attribute.Type;
+import com.webfirmframework.wffweb.tag.html.attribute.event.form.OnSubmit;
+import com.webfirmframework.wffweb.tag.html.formsandinputs.Button;
+import com.webfirmframework.wffweb.tag.html.formsandinputs.Form;
+import com.webfirmframework.wffweb.tag.html.formsandinputs.Input;
+import com.webfirmframework.wffweb.tag.html.formsandinputs.Label;
+import com.webfirmframework.wffweb.tag.html.html5.attribute.Placeholder;
+import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Div;
+import com.webfirmframework.wffweb.tag.htmlwff.TagContent;
+
+public class LoginComponent extends Div {
+
+    private final DocumentModel documentModel;
+
+    public LoginComponent(DocumentModel documentModel) {
+        super(null);
+        this.documentModel = documentModel;
+        develop();
+    }
+
+    private void develop() {
+        Div msgDiv = new Div(null);
+        new Form(this, new OnSubmit(true, event -> {
+
+            msgDiv.removeAllChildren();
+            msgDiv.removeAttributes(AttributeNameConstants.CLASS);
+
+            String username = (String) event.data().getValue("username");
+            String password = (String) event.data().getValue("password");
+
+            if ("test".equals(username) && "test".equals(password)) {
+                documentModel.httpSession().setAttribute("loginStatus", "true");
+                documentModel.browserPage().setURI(NavigationURI.USER.getUri(documentModel));
+                return null;
+            }
+
+            msgDiv.addAttributes(Bootstrap5CssClass.ALERT_DANGER.getAttribute());
+            msgDiv.give(TagContent::text, "Incorrect username or password!");
+
+            return null;
+        }, "loadingIcon.hidden = false; return {username: username.value, password: password.value};", "loadingIcon.hidden = true;")).give(form -> {
+
+            new Label(form).give(TagContent::text, "Username: ");
+            new Input(form, new Type(Type.TEXT), new Name("username"), new Placeholder("test"));
+
+            new Label(form).give(TagContent::text, "Password: ");
+            new Input(form, new Type(Type.PASSWORD), new Name("password"), new Placeholder("test"));
+
+            new Button(form, new Type(Type.SUBMIT), Bootstrap5CssClass.BTN_SECONDARY.getAttribute()).give(TagContent::text, "Login");
+
+
+        });
+
+        this.appendChild(msgDiv);
+
+    }
+
+
+}

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/UserAccountComponent.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/UserAccountComponent.java
@@ -1,0 +1,114 @@
+package com.webfirmframework.ui.page.component;
+
+import com.webfirmframework.ui.page.common.NavigationURI;
+import com.webfirmframework.ui.page.css.Bootstrap5CssClass;
+import com.webfirmframework.ui.page.model.DocumentModel;
+import com.webfirmframework.ui.page.template.SampleTemplate1;
+import com.webfirmframework.ui.page.template.SampleTemplate2;
+import com.webfirmframework.wffweb.tag.html.AbstractHtml;
+import com.webfirmframework.wffweb.tag.html.Br;
+import com.webfirmframework.wffweb.tag.html.attribute.Href;
+import com.webfirmframework.wffweb.tag.html.attribute.event.mouse.OnClick;
+import com.webfirmframework.wffweb.tag.html.formsandinputs.Button;
+import com.webfirmframework.wffweb.tag.html.links.A;
+import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Div;
+import com.webfirmframework.wffweb.tag.htmlwff.NoTag;
+import com.webfirmframework.wffweb.tag.htmlwff.TagContent;
+
+public class UserAccountComponent extends Div {
+
+    private final DocumentModel documentModel;
+
+    public UserAccountComponent(DocumentModel documentModel) {
+        super(null);
+        this.documentModel = documentModel;
+        develop();
+    }
+
+    private void develop() {
+        new Button(this,
+                Bootstrap5CssClass.BTN_PRIMARY.getAttribute(),
+                new OnClick(event -> {
+                    documentModel.httpSession().removeAttribute("loginStatus");
+                    documentModel.browserPage().setURI(NavigationURI.LOGIN.getUri(documentModel));
+                    return null;
+                }))
+                .give(TagContent::text, "Logout");
+
+
+        new Br(this);
+        new Br(this);
+
+        //navigation using client side setURI method
+        final String itemsNavigationURI = NavigationURI.VIEW_ITEMS.getUri(documentModel);
+        new A(this,
+                Bootstrap5CssClass.BTN_PRIMARY.getAttribute(),
+                new Href(itemsNavigationURI),
+                new OnClick("event.preventDefault(); wffAsync.setURI('" + itemsNavigationURI + "');"))
+                .give(TagContent::text, "View Items");
+
+        new Br(this);
+        new Br(this);
+
+        //navigation using server side setURI method
+        new A(this,
+                Bootstrap5CssClass.BTN_PRIMARY.getAttribute(),
+                new Href(itemsNavigationURI),
+                new OnClick("""
+                        event.preventDefault();
+                        loadingIcon.hidden = false;
+                        return true;""", event -> {
+                    documentModel.browserPage().setURI(NavigationURI.ADD_ITEM.getUri(documentModel));
+                    return null;
+                }, null, "loadingIcon.hidden = true;"))
+                .give(TagContent::text, "Add Item");
+
+
+        new Br(this);
+        new Br(this);
+
+        var widgetDiv = new Div(this);
+
+        ViewItemsComponent viewItems = new ViewItemsComponent();
+        AddItemComponent addItem = new AddItemComponent();
+
+        widgetDiv.whenURI(NavigationURI.VIEW_ITEMS.getPredicate(documentModel), () -> new AbstractHtml[]{viewItems});
+        widgetDiv.whenURI(NavigationURI.ADD_ITEM.getPredicate(documentModel), () -> new AbstractHtml[]{addItem});
+
+
+        SampleTemplate1 sampleTemplate1 = new SampleTemplate1(documentModel);
+
+        SampleTemplate2 sampleTemplate2 = new SampleTemplate2(documentModel);
+
+        widgetDiv.whenURI(NavigationURI.SAMPLE_TEMPLATE1.getPredicate(documentModel), () -> new AbstractHtml[]{sampleTemplate1});
+
+        widgetDiv.whenURI(NavigationURI.SAMPLE_TEMPLATE2.getPredicate(documentModel), () -> new AbstractHtml[]{sampleTemplate2});
+
+
+        sampleTemplateButtons();
+    }
+
+    private void sampleTemplateButtons() {
+
+        String sampleTemplate1URI = NavigationURI.SAMPLE_TEMPLATE1.getUri(documentModel);
+        String sampleTemplate2URI = NavigationURI.SAMPLE_TEMPLATE2.getUri(documentModel);
+
+        new Br(this);
+        new Br(this);
+        new A(this,
+                new Href(sampleTemplate1URI),
+                new OnClick("event.preventDefault(); wffAsync.setURI('" + sampleTemplate1URI + "', function(){loadingIcon.hidden = false;});"),
+                Bootstrap5CssClass.BTN_INFO_SM.getAttribute()).give(TagContent::text, "SampleTemplate1");
+
+
+        //just for space
+        new NoTag(this, " ");
+
+
+        new A(this,
+                new Href(sampleTemplate2URI),
+                new OnClick("event.preventDefault(); wffAsync.setURI('" + sampleTemplate2URI + "', function(){loadingIcon.hidden = false;});"),
+                Bootstrap5CssClass.BTN_INFO_SM.getAttribute()).give(TagContent::text, "SampleTemplate2");
+
+    }
+}

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/ViewItemsComponent.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/component/ViewItemsComponent.java
@@ -1,0 +1,18 @@
+package com.webfirmframework.ui.page.component;
+
+import com.webfirmframework.wffweb.tag.html.H1;
+import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Div;
+import com.webfirmframework.wffweb.tag.htmlwff.TagContent;
+
+public class ViewItemsComponent extends Div {
+
+    public ViewItemsComponent() {
+        super(null);
+
+        develop();
+    }
+
+    private void develop() {
+        new H1(this).give(TagContent::text, "This is view items");
+    }
+}

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/layout/IndexPageLayout.java
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/wffwebui/src/main/java/com/webfirmframework/ui/page/layout/IndexPageLayout.java
@@ -1,38 +1,37 @@
 package com.webfirmframework.ui.page.layout;
 
-import com.webfirmframework.ui.page.css.Bootstrap5CssClass;
+import com.webfirmframework.ui.page.common.NavigationURI;
+import com.webfirmframework.ui.page.component.LoginComponent;
+import com.webfirmframework.ui.page.component.UserAccountComponent;
+import com.webfirmframework.ui.page.model.DocumentModel;
 import com.webfirmframework.wffweb.server.page.BrowserPage;
 import com.webfirmframework.wffweb.tag.html.*;
 import com.webfirmframework.wffweb.tag.html.attribute.*;
-import com.webfirmframework.wffweb.tag.html.attribute.event.ServerMethod;
-import com.webfirmframework.wffweb.tag.html.attribute.event.mouse.OnClick;
+import com.webfirmframework.wffweb.tag.html.attribute.global.ClassAttribute;
 import com.webfirmframework.wffweb.tag.html.attribute.global.Id;
 import com.webfirmframework.wffweb.tag.html.attributewff.CustomAttribute;
-import com.webfirmframework.wffweb.tag.html.formsandinputs.Button;
 import com.webfirmframework.wffweb.tag.html.html5.attribute.Content;
-import com.webfirmframework.wffweb.tag.html.links.A;
+import com.webfirmframework.wffweb.tag.html.html5.attribute.global.Hidden;
 import com.webfirmframework.wffweb.tag.html.links.Link;
 import com.webfirmframework.wffweb.tag.html.metainfo.Head;
 import com.webfirmframework.wffweb.tag.html.metainfo.Meta;
 import com.webfirmframework.wffweb.tag.html.programming.Script;
 import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Div;
+import com.webfirmframework.wffweb.tag.html.stylesandsemantics.Span;
 import com.webfirmframework.wffweb.tag.htmlwff.NoTag;
-import com.webfirmframework.wffweb.tag.repository.TagRepository;
-import com.webfirmframework.wffweb.wffbm.data.BMValueType;
-import com.webfirmframework.wffweb.wffbm.data.WffBMObject;
-import com.webfirmframework.ui.page.model.DocumentModel;
-import com.webfirmframework.ui.page.template.SampleTemplate1;
+import com.webfirmframework.wffweb.tag.htmlwff.TagContent;
 import jakarta.servlet.http.HttpSession;
 
 import java.util.logging.Logger;
 
-public class IndexPageLayout extends Html implements ServerMethod {
+public class IndexPageLayout extends Html {
 
     private static final Logger LOGGER = Logger
             .getLogger(IndexPageLayout.class.getName());
 
     private final DocumentModel documentModel;
-    
+    private final String contextPath;
+
     private Div mainDiv;
 
     public IndexPageLayout(BrowserPage browserPage, HttpSession httpSession) {
@@ -40,22 +39,25 @@ public class IndexPageLayout extends Html implements ServerMethod {
         super.setPrependDocType(true);
         this.documentModel = new DocumentModel(httpSession, browserPage);
         super.setSharedData(documentModel);
+
+        contextPath = documentModel.httpSession().getServletContext().getContextPath();
         develop();
     }
 
     // @formatter:off
     private void develop() {
 
+
         new Head(this).give(head -> {
             new TitleTag(head) {{
                 new NoTag(this, "wffweb with bootstrap 5 css example");
             }};
             new Meta(head,
-                new Charset("utf-8"));
+                    new Charset("utf-8"));
             new Meta(head,
-                new Name("viewport"),
-                new Content("width=device-width, initial-scale=1"));
-            
+                    new Name("viewport"),
+                    new Content("width=device-width, initial-scale=1"));
+
             new Link(head,
                     new Href("https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"),
                     new Rel("stylesheet"),
@@ -63,115 +65,54 @@ public class IndexPageLayout extends Html implements ServerMethod {
                     new CustomAttribute("crossorigin", "anonymous"));
             new Link(head,
                     new Rel(Rel.STYLESHEET),
-                    new Href("assets/css/app.css"));
+                    new Href(contextPath + "/assets/css/app.css"));
 
-            
+
             new Script(head,
                     new Defer(),
-                    new Src("assets/js/app.js"));
-            
+                    new Src(contextPath + "/assets/js/app.js"));
+
         });
-        
+
         new Body(this).give(body -> {
-            
-            mainDiv = new Div(body, new Id("mainDivId")) .give(div -> {
+
+            mainDiv = new Div(body, new Id("mainDivId")).give(div -> {
                 new NoTag(div, "Loading...");
             });
-            
+
             new Script(body,
                     new Src("https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"),
                     new CustomAttribute("integrity", "sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"),
                     new CustomAttribute("crossorigin", "anonymous"));
-            
+
         });
-        
+
     }
-    
+
     public void buildMainDivTags() {
-        Div div = mainDiv;
-        div.removeAllChildren();
-        
-        new NoTag(div, "session id " + documentModel.httpSession().getId());
-        
-        new Br(div);
-        
-        new A(div, new Href("https://webfirmframework.github.io/developers-guide-wffweb-3/get-started.html"), 
-                new Target(Target.BLANK)) .give(a -> {
-            new NoTag(a, "visit webfirmframework developers guide");
-        });
-        
-        new Br(div);
-        
-        new A(div, new Href("https://getbootstrap.com/docs/5.1/getting-started/introduction/"),
-                new Target(Target.BLANK)).give(a -> {
-            new NoTag(a, "visit bootstrap 5 tutorial");
-        });
-        
-        new H1(div).give(h -> {
-            new NoTag(h, "Sample with bootstrap 5 css");  
-        });
-        
-        
-        
-        new Button(div, new OnClick(IndexPageLayout.this), 
-                Bootstrap5CssClass.BTN_PRIMARY.getAttribute()).give(btn -> {
-            new NoTag(btn, "Insert SampleTemplate1");
-        });
-        
-        
-        new Button(div,
-                Bootstrap5CssClass.BTN_INFO.getAttribute(),
-                new OnClick("return confirm('Do you want to send some data to server to print in server console?');", 
-                (event) -> {
 
-                    String value = (String) event.data().getValue("val");
-                    
-                    System.out.println("value: " + value);
-                    
-                    WffBMObject resultData = new WffBMObject();
-                    
-                    resultData.put("msg", 
-                            BMValueType.STRING, 
-                            "This is a message received from server!");
-                    
-                    documentModel.browserPage().getTagRepository().findTitleTag().addInnerHtml(new NoTag(null, "Some other title"));
-                    
-                    return resultData;
-                    },
-                "return {val: 'this is from client'};", 
-                "if (jsObject && jsObject.msg) {alert(jsObject.msg);}")).give(btn -> {
-            new NoTag(btn, "Send data to server");
+        mainDiv.removeAllChildren();
+        //common progress icon
+        new Div(mainDiv, new Hidden(), new Id("loadingIcon"), new ClassAttribute("spinner-border text-primary"), new Role(Role.STATUS)).give(tag -> {
+            new Span(tag, new ClassAttribute("visually-hidden")).give(TagContent::text, "Loading...");
         });
-        
-        
-        new Br(div);
-        new Br(div);
+
+        URIStateSwitch componentDiv = new Div(mainDiv);
+
+        LoginComponent loginComponent = new LoginComponent(documentModel);
+
+        UserAccountComponent userAccountComponent = new UserAccountComponent(documentModel);
+
+        componentDiv.whenURI(NavigationURI.LOGIN.getPredicate(documentModel), () -> new AbstractHtml[]{loginComponent});
+
+        componentDiv.whenURI(NavigationURI.USER.getPredicate(documentModel),
+                () -> new AbstractHtml[]{userAccountComponent},
+                event -> {
+                    documentModel.browserPage().setURI(NavigationURI.LOGIN.getUri(documentModel));
+                });
+
     }
+
     // @formatter:on
-
-    @Override
-    public WffBMObject invoke(Event event) {
-
-        TagRepository tagRepository = documentModel.browserPage()
-                .getTagRepository();
-
-        AbstractHtml mainDiv = tagRepository.findTagById("mainDivId");
-
-        final AbstractHtml firstChild = mainDiv.getFirstChild();
-
-        System.out.println(
-                "mainDiv.getFirstChild() " + firstChild.toHtmlString());
-
-        if (mainDiv != null) {
-            LOGGER.info("SampleTemplate1 appended");
-            mainDiv.appendChild(new SampleTemplate1(documentModel));
-            TitleTag titleTag = tagRepository
-                    .findOneTagAssignableToTag(TitleTag.class);
-            titleTag.addInnerHtml(new NoTag(null,
-                    "Bootstrap 5 CSS Example | SampleTemplate1"));
-        }
-
-        return null;
-    }
 
 }


### PR DESCRIPTION
In `wffweb-12.0.0-beta.1`, there is a new feature which allows to change some parts of the without refreshing the entire page. Now, multiple URIs can be used to display page with different content.

To run this project, open this project as a maven project in IntelliJ IDEA (community version is enough).