### PR TITLE
Changes for wffweb-12.0.0-beta.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ This repository contains minimal production ready webfirmframework  projects. Th
 
 ___
 
-The projects are based on latest version of *wffweb-3.0.20* and *wffweb-12.0.0-beta.8*. [Visit developers guide for webfirmframework doc](https://webfirmframework.github.io/developers-guide-wffweb-3/get-started.html).
+The projects are based on latest version of *wffweb-3.0.20* and *wffweb-12.0.0-beta.11*. [Visit developers guide for webfirmframework doc](https://webfirmframework.github.io/developers-guide-wffweb-3/get-started.html).
 
 ___
 
-`wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework` project can be run with tomcat 10 and Java 17 or later. This is the most modern way to build java web app, it uses the *wffweb-12.0.0-beta.8*. You can use any jakarta ee application server to run this project. [Checkout live demo in Heroku](https://wffweb.herokuapp.com/ui) and its single module source code can be found [here](https://github.com/webfirmframework/wffweb-demo-deployment). It uses embedded tomcat.
+`wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework` project can be run with tomcat 10 and Java 17 or later. This is the most modern way to build java web app, it uses the *wffweb-12.0.0-beta.11*. You can use any jakarta ee application server to run this project. [Checkout live demo in Heroku](https://wffweb.herokuapp.com/ui) and its single module source code can be found [here](https://github.com/webfirmframework/wffweb-demo-deployment). It uses embedded tomcat.
 ___
 
 `production-sample-jakarta-ee-with-bootstrap5-css-framework` project can be run with tomcat 10 and Java 8 or later. This is the modern way to build java web app. You can use any jakarta ee application server to run this project.

--- a/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/pom.xml
+++ b/wffweb-12-production-sample-jakarta-ee-with-bootstrap5-css-framework/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>com.webfirmframework</groupId>
 			<artifactId>wffweb</artifactId>
-			<version>12.0.0-beta.9</version>
+			<version>12.0.0-beta.11</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The wffweb version is upgraded to 12.0.0-beta.11. It doesn't contain any crucial code changes. However, it is very important to use the latest version of wffweb-12 as it is in the beta phase.